### PR TITLE
feat: add bug reporting command and beta status indicators

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,90 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the sections below.
+
+        **Tip:** You can also use `ski-parker bug` to auto-fill system info.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened?
+      placeholder: Describe the bug...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+      placeholder: I expected...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this issue?
+      placeholder: |
+        1. Run `ski-parker ...`
+        2. ...
+        3. See error
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: ski-parker version
+      description: Output of `ski-parker --version`
+      placeholder: "0.2.0"
+    validations:
+      required: true
+
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js version
+      description: Output of `node --version`
+      placeholder: "v20.0.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Linux
+        - Windows
+    validations:
+      required: true
+
+  - type: input
+    id: resort
+    attributes:
+      label: Resort URL (if applicable)
+      description: Which resort were you trying to book?
+      placeholder: "reservenski.parkstevenspass.com"
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Run with `--verbose` flag and paste any relevant output
+      render: shell
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other information that might help

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Quick Bug Report
+    url: https://github.com/ignaciohermosillacornejo/skiparker/issues/new?labels=bug
+    about: Use `ski-parker bug` command to open a pre-filled bug report

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,50 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please describe what you'd like to see.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What problem does this solve? Why would this be useful?
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How would you like this to work?
+      placeholder: It would be great if...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches you've thought about?
+      placeholder: I've also considered...
+
+  - type: dropdown
+    id: resort-specific
+    attributes:
+      label: Is this resort-specific?
+      options:
+        - "No - applies to all resorts"
+        - "Yes - specific resort (please mention below)"
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other information, screenshots, or examples

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+## Summary
+
+<!-- Brief description of the changes -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+
+## Related issues
+
+<!-- Link any related issues: Fixes #123, Relates to #456 -->
+
+## Testing
+
+- [ ] I have run `npm test` and all tests pass
+- [ ] I have run `npm run test:e2e` and e2e tests pass
+- [ ] I have added tests that prove my fix/feature works
+- [ ] I have tested against a real HONK site (if applicable)
+
+## Checklist
+
+- [ ] My code follows the project's style guidelines
+- [ ] I have performed a self-review of my code
+- [ ] I have commented hard-to-understand areas
+- [ ] I have updated documentation (if needed)
+- [ ] My changes generate no new warnings
+- [ ] Any dependent changes have been merged
+
+## Screenshots (if applicable)
+
+<!-- Add screenshots for UI changes -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `ski-parker bug` command for easy issue reporting (opens pre-filled GitHub issue)
+- Beta badge and warning message on CLI startup
+- SECURITY.md with vulnerability reporting guidelines
+- GitHub issue templates (bug report, feature request)
+- GitHub pull request template
+
+### Fixed
+- Version string in CLI now correctly shows 0.2.0 (was hardcoded as 0.1.0)
+
 ## [0.2.0] - 2026-01-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 [![npm](https://img.shields.io/npm/v/ski-parker)](https://www.npmjs.com/package/ski-parker)
 [![CI](https://github.com/ignaciohermosillacornejo/skiparker/actions/workflows/ci.yml/badge.svg)](https://github.com/ignaciohermosillacornejo/skiparker/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/ignaciohermosillacornejo/skiparker/graph/badge.svg?token=ef917b67-95c6-4703-b72c-b4938239a505)](https://codecov.io/gh/ignaciohermosillacornejo/skiparker)
+![Beta](https://img.shields.io/badge/status-beta-yellow)
+
+> **Beta Software**: This tool is under active development. Please report any issues using `ski-parker bug` or by [opening an issue](https://github.com/ignaciohermosillacornejo/skiparker/issues/new).
 
 Automated CLI for booking ski resort parking on [HONK](https://parking.honkmobile.com/)-powered sites.
 
@@ -92,6 +95,13 @@ ski-parker book --date 2026-02-15 --type paid --plate ABC1234 \
   [--headed] [--dry-run] [--verbose]
 ```
 
+### `ski-parker bug`
+Open a pre-filled GitHub issue to report a bug.
+```bash
+ski-parker bug              # Opens browser with issue form
+ski-parker bug --no-open    # Prints URL instead
+```
+
 ## Options
 
 | Option | Description |
@@ -142,6 +152,17 @@ The HONK site may have changed. Update selectors in `src/lib/scraper.ts`.
 
 ### Lot not found
 Run `ski-parker setup` to discover available lots for your resort.
+
+## Reporting Issues
+
+Found a bug or have a feature request?
+
+```bash
+# Easiest way - opens browser with system info pre-filled
+ski-parker bug
+```
+
+Or [open an issue](https://github.com/ignaciohermosillacornejo/skiparker/issues/new) directly on GitHub.
 
 ## Development
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.2.x   | :white_check_mark: |
+| < 0.2   | :x:                |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in ski-parker, please report it responsibly:
+
+1. **Do not** open a public GitHub issue for security vulnerabilities
+2. Email the maintainer directly at: hello@ignaciohermosilla.com
+3. Include:
+   - Description of the vulnerability
+   - Steps to reproduce
+   - Potential impact
+   - Any suggested fixes (optional)
+
+You can expect:
+- Acknowledgment within 48 hours
+- Status update within 7 days
+- Credit in the security advisory (unless you prefer to remain anonymous)
+
+## Security Considerations
+
+### Session Storage
+- Authentication sessions are stored locally in `~/.ski-parker/session.json`
+- This file contains cookies that grant access to your HONK account
+- Keep this file secure and do not share it
+
+### License Plate Data
+- Your license plate is stored in `~/.ski-parker/config.json`
+- This is stored in plaintext for CLI convenience
+- The config directory should have user-only read permissions
+
+### Browser Automation
+- ski-parker uses Playwright with a stealth plugin
+- No credentials are transmitted to third parties
+- All automation happens locally on your machine

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
+import { execSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
 import { authCommand } from './commands/auth.js';
 import { checkCommand } from './commands/check.js';
 import { watchCommand } from './commands/watch.js';
@@ -8,8 +11,10 @@ import { bookCommand } from './commands/book.js';
 import { setupCommand } from './commands/setup.js';
 import { loadConfig } from './lib/config.js';
 import { resolveDate, resolveType, resolvePlate, resolveResortUrl } from './lib/resolve.js';
-import { RESERVATION_TYPES, DEFAULTS } from './constants.js';
+import { RESERVATION_TYPES, DEFAULTS, PATHS } from './constants.js';
+import { log } from './lib/utils.js';
 
+const VERSION = '0.2.0';
 const config = loadConfig();
 const program = new Command();
 
@@ -18,10 +23,13 @@ function fail(error: unknown): never {
   process.exit(1);
 }
 
+// Show beta warning on startup
+log.warn('Beta software - report issues with: ski-parker bug');
+
 program
   .name('ski-parker')
   .description('Automated HONK-based ski resort parking reservation CLI')
-  .version('0.1.0');
+  .version(VERSION);
 
 // Auth command
 program
@@ -38,6 +46,65 @@ program
   .description('Configure default license plate and reservation type')
   .action(async () => {
     await setupCommand();
+  });
+
+// Bug report command
+program
+  .command('bug')
+  .description('Report a bug (opens GitHub issue in browser)')
+  .option('--no-open', 'Print URL instead of opening browser')
+  .action((opts) => {
+    const systemInfo = {
+      version: VERSION,
+      nodeVersion: process.version,
+      platform: os.platform(),
+      arch: os.arch(),
+      osRelease: os.release(),
+      configExists: fs.existsSync(PATHS.CONFIG_FILE),
+    };
+
+    const body = `## Description
+<!-- Describe what happened -->
+
+## Expected behavior
+<!-- What did you expect to happen? -->
+
+## Steps to reproduce
+1.
+2.
+3.
+
+## System information
+\`\`\`
+ski-parker: ${systemInfo.version}
+Node.js: ${systemInfo.nodeVersion}
+Platform: ${systemInfo.platform} (${systemInfo.arch})
+OS: ${systemInfo.osRelease}
+Config exists: ${systemInfo.configExists}
+\`\`\`
+
+## Additional context
+<!-- Any other relevant information -->
+`;
+
+    const url = new URL('https://github.com/ignaciohermosillacornejo/skiparker/issues/new');
+    url.searchParams.set('labels', 'bug');
+    url.searchParams.set('body', body);
+
+    if (opts.open) {
+      const openCmd = os.platform() === 'darwin' ? 'open' :
+                      os.platform() === 'win32' ? 'start' : 'xdg-open';
+      try {
+        execSync(`${openCmd} "${url.toString()}"`);
+        log.info('Opening GitHub issue page in browser...');
+      } catch {
+        console.log('\nCould not open browser. Please visit:\n');
+        console.log(url.toString());
+      }
+    } else {
+      console.log('\nOpen this URL to report a bug:\n');
+      console.log(url.toString());
+    }
   });
 
 // Check command


### PR DESCRIPTION
## Summary

- Add `ski-parker bug` command that opens pre-filled GitHub issue in browser
- Add beta warning on CLI startup (`⚠ Beta software - report issues with: ski-parker bug`)
- Add beta badge to README
- Add SECURITY.md with vulnerability reporting guidelines
- Add GitHub issue templates (bug report, feature request)
- Add GitHub pull request template
- Fix version string (was hardcoded as 0.1.0, now correctly shows 0.2.0)

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (69 tests)
- [x] `ski-parker --help` shows beta warning and bug command
- [x] `ski-parker bug --no-open` generates valid GitHub issue URL
- [x] `ski-parker --version` shows 0.2.0

🤖 Generated with [Claude Code](https://claude.ai/code)