### PR TITLE
Fix auth session restoration + setup improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ coverage/
 
 # Session data (contains auth tokens)
 .ski-parker/
+
+# Git worktrees
+.worktrees/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ski-parker",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ski-parker",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",
@@ -26,6 +26,9 @@
         "@vitest/coverage-v8": "^4.0.18",
         "typescript": "^5.9.3",
         "vitest": "^4.0.17"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -2432,6 +2435,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ski-parker",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Automated HONK-based ski resort parking reservation CLI",
   "author": "Ignacio Hermosilla <hello@ignaciohermosilla.com>",
   "license": "MIT",

--- a/src/capture-fixtures.ts
+++ b/src/capture-fixtures.ts
@@ -2,7 +2,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { createBrowser, loadSession } from './lib/browser.js';
+import { createBrowser, closeBrowser } from './lib/browser.js';
 import { URLS } from './constants.js';
 import { log, sleep } from './lib/utils.js';
 
@@ -14,8 +14,6 @@ async function captureFixtures() {
 
   const context = await createBrowser({ headed: true, verbose: true });
   const page = await context.newPage();
-
-  await loadSession(context);
 
   try {
     // Capture main reservation page
@@ -47,7 +45,7 @@ async function captureFixtures() {
   } catch (error) {
     log.error(`Capture failed: ${error}`);
   } finally {
-    await context.close();
+    await closeBrowser(context);
   }
 }
 

--- a/src/commands/book.ts
+++ b/src/commands/book.ts
@@ -1,6 +1,6 @@
 import ora from 'ora';
 import type { BookOptions } from '../types.js';
-import { createBrowser, loadSession, validateSession } from '../lib/browser.js';
+import { createBrowser, hasSession, closeBrowser, validateSession } from '../lib/browser.js';
 import { checkAvailability, bookSpot } from '../lib/scraper.js';
 import { notifyBooked, notifyError } from '../lib/notify.js';
 import { log } from '../lib/utils.js';
@@ -16,16 +16,13 @@ export async function bookCommand(options: BookOptions): Promise<void> {
 
   let context;
   try {
-    context = await createBrowser({ headed, verbose });
-    const page = await context.newPage();
-
-    spinner.text = 'Loading session...';
-    const hasSession = await loadSession(context);
-
-    if (!hasSession) {
+    if (!hasSession()) {
       spinner.fail('No saved session found. Run `ski-parker auth` first.');
       process.exit(1);
     }
+
+    context = await createBrowser({ headed, verbose });
+    const page = await context.newPage();
 
     // Validate session is still active
     spinner.text = 'Validating session...';
@@ -74,7 +71,7 @@ export async function bookCommand(options: BookOptions): Promise<void> {
     process.exit(1);
   } finally {
     if (context) {
-      await context.close();
+      await closeBrowser(context);
     }
   }
 }

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -1,7 +1,7 @@
 import ora from 'ora';
 import chalk from 'chalk';
 import type { CheckOptions, ReservationType } from '../types.js';
-import { createBrowser, loadSession, checkSessionStatus } from '../lib/browser.js';
+import { createBrowser, hasSession, closeBrowser, checkSessionStatus } from '../lib/browser.js';
 import { checkAvailability } from '../lib/scraper.js';
 import { log } from '../lib/utils.js';
 
@@ -10,6 +10,10 @@ export async function checkCommand(options: CheckOptions): Promise<void> {
 
   let context;
   try {
+    if (!hasSession()) {
+      spinner.warn('No saved session found. Run `ski-parker auth` first.');
+    }
+
     context = await createBrowser({
       headed: options.headed,
       verbose: options.verbose
@@ -17,12 +21,7 @@ export async function checkCommand(options: CheckOptions): Promise<void> {
 
     const page = await context.newPage();
 
-    spinner.text = 'Loading session...';
-    const hasSession = await loadSession(context);
-
-    if (!hasSession) {
-      spinner.warn('No saved session found. Run `ski-parker auth` first.');
-    } else {
+    if (hasSession()) {
       // Check session expiration
       const sessionStatus = await checkSessionStatus(context);
       if (sessionStatus.warning) {
@@ -69,7 +68,7 @@ export async function checkCommand(options: CheckOptions): Promise<void> {
     process.exit(1);
   } finally {
     if (context) {
-      await context.close();
+      await closeBrowser(context);
     }
   }
 }

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -2,8 +2,8 @@ import readline from 'node:readline';
 import { loadConfig, saveConfig } from '../lib/config.js';
 import { log } from '../lib/utils.js';
 import { DEFAULT_RESORT_URL, RESERVATION_TYPES } from '../constants.js';
-import { createBrowser } from '../lib/browser.js';
-import { discoverLots } from '../lib/scraper.js';
+import { createBrowser, closeBrowser } from '../lib/browser.js';
+import { discoverLots, discoverParkingTypes } from '../lib/scraper.js';
 import { authCommand } from './auth.js';
 import type { ReservationType, SetupOptions } from '../types.js';
 
@@ -35,17 +35,19 @@ export async function setupCommand(options: SetupOptions = {}): Promise<void> {
 
     const resortUrl = config.resortUrl || DEFAULT_RESORT_URL;
 
-    // Lot discovery
+    // Lot and type discovery (shared browser context)
     let discoveredLots: string[] = [];
+    let discoveredTypes: ReservationType[] = [];
     try {
       console.log();
-      log.info('Discovering parking lots...');
+      log.info('Discovering parking lots and types...');
       const context = await createBrowser({ headed: false });
       const page = await context.newPage();
       discoveredLots = await discoverLots(page, resortUrl);
-      await context.close();
+      discoveredTypes = await discoverParkingTypes(page, resortUrl);
+      await closeBrowser(context);
     } catch {
-      log.warn('Could not discover lots. Skipping lot configuration.');
+      log.warn('Could not complete discovery. Some options may need manual configuration.');
     }
 
     if (discoveredLots.length > 1) {
@@ -76,20 +78,29 @@ export async function setupCommand(options: SetupOptions = {}): Promise<void> {
     }
 
     // License plate
-    const currentPlate = config.defaultPlate || 'none';
-    const plateAnswer = await prompt(rl, `License plate [${currentPlate}]: `);
+    const platePrompt = config.defaultPlate
+      ? `License plate (e.g. ABC1234) [${config.defaultPlate}]: `
+      : 'License plate (e.g. ABC1234): ';
+    const plateAnswer = await prompt(rl, platePrompt);
     if (plateAnswer) {
       config.defaultPlate = plateAnswer.toUpperCase();
     }
 
     // Reservation type
-    const currentType = config.defaultType || 'none';
-    const typeAnswer = await prompt(rl, `Preferred type (${RESERVATION_TYPES.join('/')}) [${currentType}]: `);
-    if (typeAnswer) {
-      if (!RESERVATION_TYPES.includes(typeAnswer as ReservationType)) {
-        log.warn(`Invalid type: "${typeAnswer}". Keeping previous value.`);
-      } else {
-        config.defaultType = typeAnswer as ReservationType;
+    const validTypes = discoveredTypes.length > 0 ? discoveredTypes : [...RESERVATION_TYPES];
+
+    if (discoveredTypes.length === 1) {
+      config.defaultType = discoveredTypes[0];
+      log.info(`Single parking type available: ${discoveredTypes[0]}`);
+    } else {
+      const currentType = config.defaultType || 'none';
+      const typeAnswer = await prompt(rl, `Preferred type (${validTypes.join('/')}) [${currentType}]: `);
+      if (typeAnswer) {
+        if (!validTypes.includes(typeAnswer as ReservationType)) {
+          log.warn(`Invalid type: "${typeAnswer}". Keeping previous value.`);
+        } else {
+          config.defaultType = typeAnswer as ReservationType;
+        }
       }
     }
 

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -1,7 +1,7 @@
 import ora from 'ora';
 import chalk from 'chalk';
 import type { WatchOptions } from '../types.js';
-import { createBrowser, loadSession, checkSessionStatus } from '../lib/browser.js';
+import { createBrowser, hasSession, closeBrowser, checkSessionStatus } from '../lib/browser.js';
 import { checkAvailability, bookSpot } from '../lib/scraper.js';
 import { notifyAvailable, notifyBooked, notifyError } from '../lib/notify.js';
 import { log, sleep, jitter as jitterFn } from '../lib/utils.js';
@@ -49,13 +49,14 @@ export async function watchCommand(options: WatchOptions): Promise<void> {
   });
 
   try {
+    if (!hasSession()) {
+      log.warn('No saved session. Run `ski-parker auth` first.');
+    }
+
     context = await createBrowser({ headed, verbose });
     const page = await context.newPage();
 
-    const hasSession = await loadSession(context);
-    if (!hasSession) {
-      log.warn('No saved session. Run `ski-parker auth` first.');
-    } else {
+    if (hasSession()) {
       // Check session expiration
       const sessionStatus = await checkSessionStatus(context);
       if (!sessionStatus.valid) {
@@ -116,7 +117,7 @@ export async function watchCommand(options: WatchOptions): Promise<void> {
     process.exit(1);
   } finally {
     if (context) {
-      await context.close();
+      await closeBrowser(context);
     }
     log.info(`Completed ${checkCount} checks`);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { resolveDate, resolveType, resolvePlate, resolveResortUrl } from './lib/
 import { RESERVATION_TYPES, DEFAULTS, PATHS } from './constants.js';
 import { log } from './lib/utils.js';
 
-const VERSION = '0.3.0';
+const VERSION = '0.3.1';
 const config = loadConfig();
 const program = new Command();
 

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -16,6 +16,21 @@ export interface BrowserOptions {
   verbose?: boolean;
 }
 
+/**
+ * Check whether a saved session file exists (or test env is set).
+ */
+export function hasSession(): boolean {
+  if (process.env.SKI_PARKER_BASE_URL) return true;
+  return fs.existsSync(PATHS.SESSION_FILE);
+}
+
+/**
+ * Create a browser context.
+ *
+ * - headed mode: uses launchPersistentContext (for interactive auth)
+ * - headless mode: uses chromium.launch() + newContext({ storageState })
+ *   so that the full storage state (cookies + localStorage/origins) is restored.
+ */
 export async function createBrowser(options: BrowserOptions = {}): Promise<BrowserContext> {
   ensureConfigDir();
 
@@ -23,21 +38,59 @@ export async function createBrowser(options: BrowserOptions = {}): Promise<Brows
 
   log.verbose(`Launching browser (headed: ${headed})`, verbose);
 
-  const context = await chromium.launchPersistentContext(PATHS.CHROME_PROFILE, {
-    headless: !headed,
+  const commonArgs = [
+    '--disable-blink-features=AutomationControlled',
+    '--no-sandbox',
+  ];
+  const viewport = {
+    width: DEFAULTS.VIEWPORT_WIDTH,
+    height: DEFAULTS.VIEWPORT_HEIGHT,
+  };
+
+  if (headed) {
+    // Interactive mode — persistent context keeps profile across auth sessions
+    const context = await chromium.launchPersistentContext(PATHS.CHROME_PROFILE, {
+      headless: false,
+      channel: 'chrome',
+      args: commonArgs,
+      viewport,
+      slowMo: DEFAULTS.SLOW_MO,
+    });
+    return context;
+  }
+
+  // Headless mode — use standard launch + storageState for full session restore
+  const browser = await chromium.launch({
+    headless: true,
     channel: 'chrome',
-    args: [
-      '--disable-blink-features=AutomationControlled',
-      '--no-sandbox',
-    ],
-    viewport: {
-      width: DEFAULTS.VIEWPORT_WIDTH,
-      height: DEFAULTS.VIEWPORT_HEIGHT,
-    },
-    slowMo: DEFAULTS.SLOW_MO,
+    args: commonArgs,
   });
 
+  const contextOptions: Parameters<typeof browser.newContext>[0] = {
+    viewport,
+  };
+
+  // Restore full storage state (cookies + localStorage/origins) if available
+  if (hasSession()) {
+    contextOptions.storageState = PATHS.SESSION_FILE;
+    log.verbose('Restoring session from storage state', verbose);
+  }
+
+  const context = await browser.newContext(contextOptions);
   return context;
+}
+
+/**
+ * Close a browser context and its parent browser (if any).
+ * Handles both persistent contexts (no parent browser) and standard contexts.
+ */
+export async function closeBrowser(context: BrowserContext): Promise<void> {
+  await context.close();
+  // Standard contexts have a parent browser that also needs closing
+  const browser = context.browser();
+  if (browser) {
+    await browser.close();
+  }
 }
 
 export async function saveSession(context: BrowserContext): Promise<void> {
@@ -45,25 +98,6 @@ export async function saveSession(context: BrowserContext): Promise<void> {
   const state = await context.storageState();
   fs.writeFileSync(PATHS.SESSION_FILE, JSON.stringify(state, null, 2));
   log.success('Session saved');
-}
-
-export async function loadSession(context: BrowserContext): Promise<boolean> {
-  // Skip session requirement when running against mock server (e2e tests)
-  if (process.env.SKI_PARKER_BASE_URL) {
-    return true;
-  }
-
-  if (!fs.existsSync(PATHS.SESSION_FILE)) {
-    return false;
-  }
-
-  try {
-    const state = JSON.parse(fs.readFileSync(PATHS.SESSION_FILE, 'utf-8'));
-    await context.addCookies(state.cookies || []);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 export async function isLoggedIn(page: Page, resortUrl?: string): Promise<boolean> {

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -76,8 +76,16 @@ export async function createBrowser(options: BrowserOptions = {}): Promise<Brows
     log.verbose('Restoring session from storage state', verbose);
   }
 
-  const context = await browser.newContext(contextOptions);
-  return context;
+  try {
+    const context = await browser.newContext(contextOptions);
+    return context;
+  } catch {
+    // Session file may be corrupted — fall back to fresh context
+    log.warn('Session file corrupted, proceeding without session');
+    delete contextOptions.storageState;
+    const context = await browser.newContext(contextOptions);
+    return context;
+  }
 }
 
 /**

--- a/src/lib/scraper.ts
+++ b/src/lib/scraper.ts
@@ -92,6 +92,26 @@ export async function discoverLots(page: Page, resortUrl: string, verbose = fals
   return lots;
 }
 
+async function clickFirstAvailableDate(page: Page): Promise<boolean> {
+  for (let monthAttempt = 0; monthAttempt < 3; monthAttempt++) {
+    const dayElements = await page.$$('.mbsc-calendar-day-text');
+    for (const day of dayElements) {
+      const style = await day.getAttribute('style') || '';
+      if (style.includes(CALENDAR_COLORS.available)) {
+        await day.click();
+        await sleep(1000);
+        return true;
+      }
+    }
+    const nextBtn = await page.$(SELECTORS.calendarNextBtn);
+    if (nextBtn) {
+      await nextBtn.click();
+      await sleep(500);
+    }
+  }
+  return false;
+}
+
 export async function discoverParkingTypes(
   page: Page,
   resortUrl: string,
@@ -114,28 +134,7 @@ export async function discoverParkingTypes(
   await page.waitForSelector(SELECTORS.calendar, { timeout: 15000 });
   await sleep(500);
 
-  // Look for any available date in current/next months
-  let foundDate = false;
-  for (let monthAttempt = 0; monthAttempt < 3 && !foundDate; monthAttempt++) {
-    const dayElements = await page.$$('.mbsc-calendar-day-text');
-    for (const day of dayElements) {
-      const style = await day.getAttribute('style') || '';
-      if (style.includes(CALENDAR_COLORS.available)) {
-        await day.click();
-        await sleep(1000);
-        foundDate = true;
-        break;
-      }
-    }
-    if (!foundDate) {
-      const nextBtn = await page.$(SELECTORS.calendarNextBtn);
-      if (nextBtn) {
-        await nextBtn.click();
-        await sleep(500);
-      }
-    }
-  }
-
+  const foundDate = await clickFirstAvailableDate(page);
   if (!foundDate) {
     log.verbose('No available dates found for type discovery', verbose);
     return [];
@@ -435,9 +434,12 @@ export async function bookSpot(
           await sleep(1000);
 
           // Look for the configured plate in the vehicle list
-          const vehicleOption = await page.$(`text="${plate}"`);
-          if (vehicleOption) {
-            await vehicleOption.click();
+          // Use BEM class selector (HONK's vehicle component) with text match
+          const vehicleOption = await page.$(`.CheckoutVehicleComponent--plate:has-text("${plate}")`);
+          // Fall back to broader text match within the vehicle modal
+          const target = vehicleOption ?? await page.$(`[class*="Vehicle"] >> text="${plate}"`);
+          if (target) {
+            await target.click();
             await sleep(1000);
             log.verbose(`Selected vehicle with plate: ${plate}`, verbose);
           } else {

--- a/src/lib/scraper.ts
+++ b/src/lib/scraper.ts
@@ -92,6 +92,71 @@ export async function discoverLots(page: Page, resortUrl: string, verbose = fals
   return lots;
 }
 
+export async function discoverParkingTypes(
+  page: Page,
+  resortUrl: string,
+  verbose = false,
+): Promise<ReservationType[]> {
+  log.verbose('Discovering available parking types...', verbose);
+
+  await page.goto(`${resortUrl}/select-parking`, { waitUntil: 'networkidle' });
+  await sleep(2000);
+
+  // Handle lot selection — pick first lot if multi-lot site
+  const lotCards = await page.$$(SELECTORS.lotDiscovery);
+  if (lotCards.length > 0) {
+    log.verbose(`Multi-lot site, selecting first lot for type discovery`, verbose);
+    await lotCards[0].click();
+    await sleep(1500);
+  }
+
+  // Wait for calendar and find a green (available) date to click
+  await page.waitForSelector(SELECTORS.calendar, { timeout: 15000 });
+  await sleep(500);
+
+  // Look for any available date in current/next months
+  let foundDate = false;
+  for (let monthAttempt = 0; monthAttempt < 3 && !foundDate; monthAttempt++) {
+    const dayElements = await page.$$('.mbsc-calendar-day-text');
+    for (const day of dayElements) {
+      const style = await day.getAttribute('style') || '';
+      if (style.includes(CALENDAR_COLORS.available)) {
+        await day.click();
+        await sleep(1000);
+        foundDate = true;
+        break;
+      }
+    }
+    if (!foundDate) {
+      const nextBtn = await page.$(SELECTORS.calendarNextBtn);
+      if (nextBtn) {
+        await nextBtn.click();
+        await sleep(500);
+      }
+    }
+  }
+
+  if (!foundDate) {
+    log.verbose('No available dates found for type discovery', verbose);
+    return [];
+  }
+
+  // Check which rate cards are present
+  const types: ReservationType[] = [];
+  const rateWrapper = await page.$(SELECTORS.activeRateContainer);
+  if (!rateWrapper) {
+    log.verbose('Rate selection not shown after clicking date', verbose);
+    return [];
+  }
+
+  if (await page.$(SELECTORS.rateCard('Paid'))) types.push('paid');
+  if (await page.$(SELECTORS.rateCard('Carpool'))) types.push('carpool');
+  if (await page.$(SELECTORS.rateCard('Free'))) types.push('free');
+
+  log.verbose(`Discovered parking types: ${types.join(', ')}`, verbose);
+  return types;
+}
+
 export async function navigateToReservations(page: Page, verbose = false, resortUrl?: string): Promise<void> {
   log.verbose('Navigating to reservation page', verbose);
   const urls = getUrls(resortUrl);
@@ -354,21 +419,31 @@ export async function bookSpot(
     await page.waitForSelector(SELECTORS.checkoutContainer, { timeout: 15000 });
     log.verbose('On checkout page', verbose);
 
-    // Check if we need to update the license plate
+    // Verify the correct license plate is selected
     const currentPlate = await page.$(SELECTORS.plateDisplay);
     if (currentPlate) {
-      const displayedPlate = await currentPlate.textContent();
+      const displayedPlate = (await currentPlate.textContent())?.trim();
       log.verbose(`Current plate: ${displayedPlate}`, verbose);
 
       if (displayedPlate !== plate) {
-        // Click edit to change plate
+        log.verbose(`Plate mismatch: displayed=${displayedPlate}, wanted=${plate}`, verbose);
+
+        // Click "Edit vehicle" to open vehicle selection modal
         const editBtn = await page.$(SELECTORS.editVehicleBtn);
         if (editBtn) {
           await editBtn.click();
-          await sleep(500);
-          // Plate editing modal flow would go here
-          // For now, log a warning
-          log.warn(`Plate mismatch: displayed=${displayedPlate}, wanted=${plate}`);
+          await sleep(1000);
+
+          // Look for the configured plate in the vehicle list
+          const vehicleOption = await page.$(`text="${plate}"`);
+          if (vehicleOption) {
+            await vehicleOption.click();
+            await sleep(1000);
+            log.verbose(`Selected vehicle with plate: ${plate}`, verbose);
+          } else {
+            result.error = `License plate ${plate} is not registered to your HONK account. Add it at parking.honkmobile.com first, or run \`ski-parker setup\` to change your plate.`;
+            return result;
+          }
         }
       }
     }

--- a/tests/e2e/book.test.ts
+++ b/tests/e2e/book.test.ts
@@ -1,9 +1,15 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { execSync } from 'node:child_process';
 import path from 'node:path';
-import { startMockServer, stopMockServer, getMockUrl, setScenarioViaApi } from './helpers';
+import { startMockServer, stopMockServer, getMockUrl, setScenarioViaApi, futureDate } from './helpers';
 
 const CLI = `node ${path.resolve('dist/index.js')}`;
+
+// Dynamic future dates to avoid "date in the past" errors
+const AVAILABLE_DATE = futureDate(7);
+const SOLD_OUT_DATE = futureDate(8);
+const NO_RESERVATION_DATE = futureDate(9);
+const UNAVAILABLE_DATE = futureDate(10);
 
 function runCli(args: string): { stdout: string; exitCode: number } {
   try {
@@ -28,79 +34,90 @@ describe('book command (E2E)', () => {
   });
 
   beforeEach(async () => {
-    await setScenarioViaApi({});
+    await setScenarioViaApi({
+      dates: {
+        [AVAILABLE_DATE]: 'available',
+        [SOLD_OUT_DATE]: 'sold-out',
+        [NO_RESERVATION_DATE]: 'no-reservation',
+      },
+    });
   });
 
   it('books successfully with confirm modal', async () => {
-    // 2026-02-14 is available in default scenario, checkoutOutcome defaults to 'confirm'
-    const { stdout, exitCode } = runCli('book --date 2026-02-14 --type carpool --plate CFH2637 --verbose');
+    const { stdout, exitCode } = runCli(`book --date ${AVAILABLE_DATE} --type carpool --plate CFH2637 --verbose`);
     expect(exitCode).toBe(0);
-    expect(stdout).toContain('Date: 2026-02-14');
+    expect(stdout).toContain(`Date: ${AVAILABLE_DATE}`);
     expect(stdout).toContain('Type: carpool');
   });
 
   it('reports overlap error', async () => {
-    // 2026-02-14 is available in defaults, just override checkout outcome
-    await setScenarioViaApi({ checkoutOutcome: 'overlap' });
+    await setScenarioViaApi({
+      dates: { [AVAILABLE_DATE]: 'available' },
+      checkoutOutcome: 'overlap',
+    });
 
-    const { stdout, exitCode } = runCli('book --date 2026-02-14 --type carpool --plate CFH2637 --verbose');
+    const { stdout, exitCode } = runCli(`book --date ${AVAILABLE_DATE} --type carpool --plate CFH2637 --verbose`);
     expect(exitCode).toBe(1);
     expect(stdout).toContain('overlap');
   });
 
   it('reports reservation limit error', async () => {
-    await setScenarioViaApi({ checkoutOutcome: 'limit' });
+    await setScenarioViaApi({
+      dates: { [AVAILABLE_DATE]: 'available' },
+      checkoutOutcome: 'limit',
+    });
 
-    const { stdout, exitCode } = runCli('book --date 2026-02-14 --type carpool --plate CFH2637 --verbose');
+    const { stdout, exitCode } = runCli(`book --date ${AVAILABLE_DATE} --type carpool --plate CFH2637 --verbose`);
     expect(exitCode).toBe(1);
     expect(stdout).toContain('reservation limit');
   });
 
   it('books paid parking successfully', async () => {
-    const { stdout, exitCode } = runCli('book --date 2026-02-14 --type paid --plate CFH2637 --verbose');
+    const { stdout, exitCode } = runCli(`book --date ${AVAILABLE_DATE} --type paid --plate CFH2637 --verbose`);
     expect(exitCode).toBe(0);
     expect(stdout).toContain('Type: paid');
   });
 
   it('reports unavailable for a date not in scenario', async () => {
-    const { stdout, exitCode } = runCli('book --date 2026-02-09 --type carpool --plate CFH2637 --verbose');
+    const { stdout, exitCode } = runCli(`book --date ${UNAVAILABLE_DATE} --type carpool --plate CFH2637 --verbose`);
     expect(exitCode).toBe(1);
     expect(stdout).toContain('not available');
   });
 
   it('reports sold out date as not available', async () => {
-    const { stdout, exitCode } = runCli('book --date 2026-02-07 --type carpool --plate CFH2637 --verbose');
+    const { stdout, exitCode } = runCli(`book --date ${SOLD_OUT_DATE} --type carpool --plate CFH2637 --verbose`);
     expect(exitCode).toBe(1);
     expect(stdout).toContain('not available');
   });
 
   it('reports no-reservation date as not available', async () => {
-    // 2026-02-16 is no-reservation in default scenario
-    const { stdout, exitCode } = runCli('book --date 2026-02-16 --type carpool --plate CFH2637 --verbose');
+    const { stdout, exitCode } = runCli(`book --date ${NO_RESERVATION_DATE} --type carpool --plate CFH2637 --verbose`);
     expect(exitCode).toBe(1);
     expect(stdout).toContain('not available');
   });
 
   it('rejects invalid reservation type', () => {
-    const { stdout, exitCode } = runCli('book --date 2026-02-14 --type express --plate CFH2637');
+    const { stdout, exitCode } = runCli(`book --date ${AVAILABLE_DATE} --type express --plate CFH2637`);
     expect(exitCode).toBe(1);
     expect(stdout).toContain('Invalid type');
   });
 
   it('dry run stops before confirmation', async () => {
-    // 2026-02-14 is available in defaults
-    const { stdout, exitCode } = runCli('book --date 2026-02-14 --type carpool --plate CFH2637 --dry-run --verbose');
+    const { stdout, exitCode } = runCli(`book --date ${AVAILABLE_DATE} --type carpool --plate CFH2637 --dry-run --verbose`);
     expect(exitCode).toBe(0);
     expect(stdout).toContain('Dry run');
     expect(stdout).toContain('DRY-RUN');
   });
 
   it('books successfully with multi-lot selection', async () => {
-    await setScenarioViaApi({ lots: ['Lot A', 'Lot B'] });
+    await setScenarioViaApi({
+      dates: { [AVAILABLE_DATE]: 'available' },
+      lots: ['Lot A', 'Lot B'],
+    });
 
-    const { stdout, exitCode } = runCli('book --date 2026-02-14 --type carpool --plate CFH2637 --lot "Lot A" --verbose');
+    const { stdout, exitCode } = runCli(`book --date ${AVAILABLE_DATE} --type carpool --plate CFH2637 --lot "Lot A" --verbose`);
     expect(exitCode).toBe(0);
-    expect(stdout).toContain('Date: 2026-02-14');
+    expect(stdout).toContain(`Date: ${AVAILABLE_DATE}`);
     expect(stdout).toContain('Type: carpool');
   });
 });

--- a/tests/e2e/check.test.ts
+++ b/tests/e2e/check.test.ts
@@ -1,9 +1,15 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { execSync } from 'node:child_process';
 import path from 'node:path';
-import { startMockServer, stopMockServer, getMockUrl, setScenarioViaApi } from './helpers';
+import { startMockServer, stopMockServer, getMockUrl, setScenarioViaApi, futureDate } from './helpers';
 
 const CLI = `node ${path.resolve('dist/index.js')}`;
+
+// Dynamic future dates to avoid "date in the past" errors
+const AVAILABLE_DATE = futureDate(7);
+const SOLD_OUT_DATE = futureDate(8);
+const NO_RESERVATION_DATE = futureDate(9);
+const UNAVAILABLE_DATE = futureDate(10);
 
 function runCli(args: string): { stdout: string; exitCode: number } {
   try {
@@ -28,31 +34,33 @@ describe('check command (E2E)', () => {
   });
 
   beforeEach(async () => {
-    await setScenarioViaApi({});
+    await setScenarioViaApi({
+      dates: {
+        [AVAILABLE_DATE]: 'available',
+        [SOLD_OUT_DATE]: 'sold-out',
+        [NO_RESERVATION_DATE]: 'no-reservation',
+      },
+    });
   });
 
   it('shows available types for an available date', async () => {
-    // 2026-02-14 is available in default scenario
-    const { stdout, exitCode } = runCli('check --date 2026-02-14 --verbose');
+    const { stdout, exitCode } = runCli(`check --date ${AVAILABLE_DATE} --verbose`);
     expect(exitCode).toBe(0);
     expect(stdout).toContain('Available');
   });
 
   it('shows sold out for a sold-out date', async () => {
-    // 2026-02-07 is sold-out in default scenario
-    const { stdout } = runCli('check --date 2026-02-07 --verbose');
+    const { stdout } = runCli(`check --date ${SOLD_OUT_DATE} --verbose`);
     expect(stdout).toContain('Sold out');
   });
 
   it('shows no reservation needed for a no-reservation date', async () => {
-    // 2026-02-16 is no-reservation in default scenario
-    const { stdout } = runCli('check --date 2026-02-16 --verbose');
+    const { stdout } = runCli(`check --date ${NO_RESERVATION_DATE} --verbose`);
     expect(stdout).toContain('No reservation needed');
   });
 
   it('shows unavailable for a date not in scenario', async () => {
-    // 2026-02-09 is not in the default scenario
-    const { stdout } = runCli('check --date 2026-02-09 --verbose');
+    const { stdout } = runCli(`check --date ${UNAVAILABLE_DATE} --verbose`);
     expect(stdout).toContain('unavailable');
   });
 
@@ -69,9 +77,12 @@ describe('check command (E2E)', () => {
   });
 
   it('shows available types for a multi-lot resort', async () => {
-    await setScenarioViaApi({ lots: ['Lot A', 'Lot B'] });
+    await setScenarioViaApi({
+      dates: { [AVAILABLE_DATE]: 'available' },
+      lots: ['Lot A', 'Lot B'],
+    });
 
-    const { stdout, exitCode } = runCli('check --date 2026-02-14 --lot "Lot A" --verbose');
+    const { stdout, exitCode } = runCli(`check --date ${AVAILABLE_DATE} --lot "Lot A" --verbose`);
     expect(exitCode).toBe(0);
     expect(stdout).toContain('Available');
   });

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -48,6 +48,16 @@ export function getMockUrl(): string {
   return MOCK_URL;
 }
 
+/**
+ * Generate a future date string in YYYY-MM-DD format.
+ * @param daysFromNow - Number of days in the future (default 7)
+ */
+export function futureDate(daysFromNow = 7): string {
+  const d = new Date();
+  d.setDate(d.getDate() + daysFromNow);
+  return d.toISOString().split('T')[0];
+}
+
 export async function setScenarioViaApi(scenario: Record<string, unknown>): Promise<void> {
   for (let attempt = 0; attempt < 5; attempt++) {
     try {

--- a/tests/e2e/watch.test.ts
+++ b/tests/e2e/watch.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { spawn } from 'node:child_process';
 import path from 'node:path';
-import { startMockServer, stopMockServer, getMockUrl, setScenarioViaApi } from './helpers';
+import { startMockServer, stopMockServer, getMockUrl, setScenarioViaApi, futureDate } from './helpers';
 
 const CLI = path.resolve('dist/index.js');
+
+// Dynamic future dates to avoid "date in the past" errors
+const AVAILABLE_DATE = futureDate(7);
+const UNAVAILABLE_DATE = futureDate(10);
 
 describe('watch command (E2E)', () => {
   beforeAll(async () => {
@@ -15,12 +19,15 @@ describe('watch command (E2E)', () => {
   });
 
   beforeEach(async () => {
-    await setScenarioViaApi({});
+    await setScenarioViaApi({
+      dates: {
+        [AVAILABLE_DATE]: 'available',
+      },
+    });
   });
 
   it('exits immediately when date is already available', async () => {
-    // 2026-02-14 is available in the default scenario
-    const proc = spawn('node', [CLI, 'watch', '--date', '2026-02-14', '--type', 'carpool', '--interval', '3', '--jitter', '0', '--verbose'], {
+    const proc = spawn('node', [CLI, 'watch', '--date', AVAILABLE_DATE, '--type', 'carpool', '--interval', '3', '--jitter', '0', '--verbose'], {
       env: { ...process.env, SKI_PARKER_BASE_URL: getMockUrl() },
     });
 
@@ -44,8 +51,12 @@ describe('watch command (E2E)', () => {
   }, 60000);
 
   it('auto-books when availability is detected', async () => {
-    // 2026-02-09 starts unavailable, then becomes available
-    const proc = spawn('node', [CLI, 'watch', '--date', '2026-02-09', '--type', 'carpool', '--interval', '3', '--jitter', '0', '--auto-book', '--plate', 'CFH2637', '--verbose'], {
+    // Start with date unavailable
+    await setScenarioViaApi({
+      dates: {},
+    });
+
+    const proc = spawn('node', [CLI, 'watch', '--date', UNAVAILABLE_DATE, '--type', 'carpool', '--interval', '3', '--jitter', '0', '--auto-book', '--plate', 'CFH2637', '--verbose'], {
       env: { ...process.env, SKI_PARKER_BASE_URL: getMockUrl() },
     });
 
@@ -55,7 +66,7 @@ describe('watch command (E2E)', () => {
 
     // After 2s, make the date available
     await new Promise(r => setTimeout(r, 2000));
-    await setScenarioViaApi({ dates: { '2026-02-09': 'available' } });
+    await setScenarioViaApi({ dates: { [UNAVAILABLE_DATE]: 'available' } });
 
     const exitCode = await new Promise<number>((resolve, reject) => {
       const timeout = setTimeout(() => {
@@ -74,8 +85,12 @@ describe('watch command (E2E)', () => {
   }, 90000);
 
   it('detects availability change during polling', async () => {
-    // 2026-02-09 is not in the default scenario (unavailable)
-    const proc = spawn('node', [CLI, 'watch', '--date', '2026-02-09', '--type', 'carpool', '--interval', '3', '--jitter', '0', '--verbose'], {
+    // Start with date unavailable
+    await setScenarioViaApi({
+      dates: {},
+    });
+
+    const proc = spawn('node', [CLI, 'watch', '--date', UNAVAILABLE_DATE, '--type', 'carpool', '--interval', '3', '--jitter', '0', '--verbose'], {
       env: { ...process.env, SKI_PARKER_BASE_URL: getMockUrl() },
     });
 
@@ -85,7 +100,7 @@ describe('watch command (E2E)', () => {
 
     // After 2s, make the date available
     await new Promise(r => setTimeout(r, 2000));
-    await setScenarioViaApi({ dates: { '2026-02-09': 'available' } });
+    await setScenarioViaApi({ dates: { [UNAVAILABLE_DATE]: 'available' } });
 
     // Wait for process to exit (it breaks out of the loop on availability)
     const exitCode = await new Promise<number>((resolve, reject) => {


### PR DESCRIPTION
## Summary
- **Fix session bug**: Headless commands now use `chromium.launch()` + `newContext({ storageState })` instead of `launchPersistentContext` — restores full browser state (cookies + localStorage/origins) so `ski-parker book` works after `ski-parker auth`
- **Auto-discover parking types**: Setup probes the resort calendar to find which rate cards exist (paid/carpool/free), auto-selecting if only one type available
- **License plate UX**: Setup prompt shows example format (`e.g. ABC1234`); booking now selects the correct vehicle from HONK's vehicle list instead of just warning on mismatch

## Test Plan
- [x] `npm run build` — compiles cleanly
- [x] `npm test` — 69/69 tests pass
- [ ] Manual: `ski-parker auth` then `ski-parker book --date <future-date>` — session persists
- [ ] Manual: `ski-parker setup` — auto-discovers types, shows example plate format

🤖 Generated with [Claude Code](https://claude.com/claude-code)