### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-03-07
+
+### Changed
+- Simplified to watch-only availability monitor — `check` and `book` commands removed since Cloudflare Turnstile blocks automated interactions after clicking calendar dates
+- `watch` command is now a pure availability monitor: notifies when a date becomes available, user books manually
+- `setup` command simplified (removed plate/type configuration)
+- Extracted magic numbers (timeouts, retry counts, delays) to named constants
+- Replaced `exec()` with `execFile()` in notifications to eliminate shell injection surface
+
+### Removed
+- `check` and `book` commands and all booking infrastructure (`bookSpot()`, `waitForTurnstile()`, `notifyBooked()`, `notifyError()`, `ReservationType`, `BookingResult`, `BookOptions`, `CheckOptions`)
+
 ## [0.3.0] - 2026-02-02
 
 ### Added
@@ -62,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dry-run mode for testing without booking
 - Verbose logging option
 
+[0.4.0]: https://github.com/ignaciohermosillacornejo/skiparker/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/ignaciohermosillacornejo/skiparker/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/ignaciohermosillacornejo/skiparker/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/ignaciohermosillacornejo/skiparker/releases/tag/v0.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ski-parker",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ski-parker",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ski-parker",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Automated HONK-based ski resort parking reservation CLI",
   "author": "Ignacio Hermosilla <hello@ignaciohermosilla.com>",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { resolveDate, resolveResortUrl } from './lib/resolve.js';
 import { DEFAULTS, PATHS } from './constants.js';
 import { log } from './lib/utils.js';
 
-const VERSION = '0.3.1';
+const VERSION = '0.4.0';
 const config = loadConfig();
 const program = new Command();
 


### PR DESCRIPTION
## Summary
- Bumps version to 0.4.0 across `package.json`, `package-lock.json`, and `src/index.ts`
- Adds CHANGELOG entry for v0.4.0: simplified to watch-only monitor, removed `check`/`book` commands (Cloudflare Turnstile), extracted magic numbers, safer `execFile` for notifications

## Test plan
- [ ] Merge PR
- [ ] Run `gh workflow run "Publish to npm"` to publish 0.4.0
- [ ] Verify with `npm view ski-parker version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)