### PR TITLE
feat: add Crystal Mountain parking support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,20 @@
 
 > **Beta Software**: This tool is under active development. Please report any issues using `ski-parker bug` or by [opening an issue](https://github.com/ignaciohermosillacornejo/skiparker/issues/new).
 
-CLI tool that monitors ski resort parking availability on [HONK](https://parking.honkmobile.com/)-powered sites and notifies you when a spot opens up so you can book manually.
+CLI tool that monitors ski resort parking availability and notifies you when a spot opens up so you can book manually. Supports **HONK**-powered sites and **Crystal Mountain Resort** (separate platform).
 
-HONK is the parking reservation platform used by many ski resorts across North America. This tool watches the calendar for availability changes and sends desktop notifications when parking opens up.
+HONK is the parking reservation platform used by many ski resorts across North America. Crystal Mountain (WA) uses its own parking site. The tool watches the calendar for availability changes and sends desktop notifications when parking opens up.
 
 ## Supported Resorts
+
+### Crystal Mountain (WA)
+| Resort | URL | Platform |
+|--------|-----|----------|
+| Crystal Mountain | [parking.crystalmountainresort.com](https://parking.crystalmountainresort.com/) | Crystal |
+
+Use `resortUrl: "https://parking.crystalmountainresort.com"` in config. No lot selection (single product).
+
+### HONK Reserve 'N Ski (13 portals)
 
 Validated against all 13 HONK Reserve 'N Ski portals:
 
@@ -31,7 +40,7 @@ Validated against all 13 HONK Reserve 'N Ski portals:
 | Alta | UT | reserve.altaparking.com | Single-lot |
 | Whistler Blackcomb | BC | reservenski.whistlerblackcombparking.com | Multi-lot |
 
-See [docs/honk-resorts-research.md](docs/honk-resorts-research.md) for detailed resort information including pricing, carpool rules, and edge cases.
+See [docs/honk-resorts-research.md](docs/honk-resorts-research.md) for detailed HONK resort information including pricing, carpool rules, and edge cases.
 
 ## Installation
 
@@ -119,6 +128,15 @@ Config file: `~/.ski-parker/config.json`
 }
 ```
 
+For Crystal Mountain, use:
+```json
+{
+  "resortUrl": "https://parking.crystalmountainresort.com",
+  "pollInterval": 60,
+  "jitter": 20
+}
+```
+
 ## Troubleshooting
 
 ### Session expired
@@ -161,14 +179,16 @@ npx tsx scripts/validate-selectors.ts
 ```
 src/
   lib/
-    selectors.ts    # Pure selector functions (unit tested)
-    scraper.ts      # Browser automation (e2e tested)
-    config.ts       # Configuration management
-    utils.ts        # Utility functions
+    selectors.ts       # HONK selector functions (unit tested)
+    selectors-crystal.ts  # Crystal Mountain selectors
+    scraper.ts        # Browser automation; dispatches to HONK or Crystal
+    scraper-crystal.ts   # Crystal Mountain flow
+    config.ts         # Configuration management
+    utils.ts          # Utility functions
 tests/
-  lib/              # Unit tests
-  e2e/              # End-to-end tests
-  mock-server/      # Mock HONK server for e2e
+  lib/                # Unit tests
+  e2e/                # End-to-end tests
+  mock-server/        # Mock HONK server for e2e
 scripts/
-  validate-selectors.ts  # Test selectors against real sites
+  validate-selectors.ts  # Test selectors against real HONK sites
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1917,7 +1917,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1930,7 +1929,6 @@
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
       "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright-core": "1.57.0"
       },
@@ -1961,7 +1959,6 @@
       "resolved": "https://registry.npmjs.org/playwright-extra/-/playwright-extra-4.3.6.tgz",
       "integrity": "sha512-q2rVtcE8V8K3vPVF1zny4pvwZveHLH8KBuVU2MoE3Jw4OKVoBWsHI9CH9zPydovHHOCDxjGN2Vg+2m644q3ijA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -2435,7 +2432,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2526,7 +2522,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -23,7 +23,7 @@ export async function authCommand(options: AuthOptions): Promise<void> {
       return;
     }
 
-    spinner.info('Please log in to your HONK account in the browser window.');
+    spinner.info('Please log in to the resort parking site in the browser window.');
     spinner.start('Waiting for login...');
 
     const loggedIn = await waitForLogin(page, options.verbose, options.resortUrl);

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -87,7 +87,7 @@ export async function setupCommand(options: SetupOptions = {}): Promise<void> {
 
     // Prompt for authentication
     console.log();
-    const authAnswer = await prompt(rl, 'Authenticate with HONK now? (Y/n): ');
+    const authAnswer = await prompt(rl, 'Authenticate now? (Y/n): ');
     const shouldAuth = !authAnswer || authAnswer.toLowerCase() === 'y' || authAnswer.toLowerCase() === 'yes';
 
     rl.close();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,14 +3,42 @@ import os from 'node:os';
 
 export const DEFAULT_RESORT_URL = 'https://reservenski.parkstevenspass.com';
 
+/** Crystal Mountain Resort parking (non-HONK platform). */
+export const CRYSTAL_MOUNTAIN_URL = 'https://parking.crystalmountainresort.com';
+
+export type Platform = 'honk' | 'crystal';
+
+/**
+ * Detect platform from resort URL. Used to choose scraper flow and URL paths.
+ */
+export function getPlatform(resortUrl?: string): Platform {
+  const raw = process.env.SKI_PARKER_BASE_URL || resortUrl || DEFAULT_RESORT_URL;
+  const url = raw.replace(/\/+$/, '');
+  if (url.includes('crystalmountainresort.com')) return 'crystal';
+  return 'honk';
+}
+
 export function getUrls(resortUrl?: string) {
   // Environment variable takes precedence (for testing)
   const raw = process.env.SKI_PARKER_BASE_URL || resortUrl || DEFAULT_RESORT_URL;
   const base = raw.replace(/\/+$/, ''); // strip trailing slashes
+  const platform = getPlatform(resortUrl);
+
+  if (platform === 'crystal') {
+    return {
+      BASE: base,
+      LOGIN: `${base}/login`,
+      PROMO: `${base}/login`, // Crystal uses login for account
+      /** Crystal reservations are on the main page (no /select-parking). */
+      RESERVATIONS: base,
+    };
+  }
+
   return {
     BASE: base,
     LOGIN: `${base}/login`,
     PROMO: `${base}/code`,
+    RESERVATIONS: `${base}/select-parking`,
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ program
 // Auth command
 program
   .command('auth')
-  .description('Authenticate with HONK (opens browser for manual login)')
+  .description('Authenticate with resort parking site (opens browser for manual login)')
   .option('-v, --verbose', 'Enable verbose logging', false)
   .action(async (opts) => {
     await authCommand({ verbose: opts.verbose, resortUrl: config.resortUrl });

--- a/src/lib/scraper-crystal.ts
+++ b/src/lib/scraper-crystal.ts
@@ -1,0 +1,179 @@
+/**
+ * Scraper for Crystal Mountain Resort parking (parking.crystalmountainresort.com).
+ * Crystal uses a different platform than HONK; this module implements the same
+ * high-level operations (navigate, check availability, login, discover lots).
+ */
+
+import type { Page, ElementHandle } from 'playwright-core';
+import type { AvailabilityResult } from '../types.js';
+import { getUrls } from '../constants.js';
+import { sleep, log } from './utils.js';
+import {
+  buildCrystalCalendarDaySelectors,
+  CRYSTAL_SELECTORS,
+  parseCrystalAvailability,
+} from './selectors-crystal.js';
+
+const CALENDAR_LOAD_TIMEOUT_MS = 15000;
+const CALENDAR_RENDER_DELAY_MS = 500;
+const SPA_RENDER_DELAY_MS = 1500;
+const MONTH_NAVIGATION_DELAY_MS = 500;
+const MAX_CALENDAR_NAVIGATION_ATTEMPTS = 6;
+
+async function findVisible(page: Page, selector: string): Promise<ElementHandle | null> {
+  const elements = await page.$$(selector);
+  for (const el of elements) {
+    if (await el.isVisible()) return el;
+  }
+  return elements[0] ?? null;
+}
+
+/** Crystal reservations are on the main page (no lot selection). */
+export async function navigateToReservations(
+  page: Page,
+  verbose = false,
+  resortUrl?: string
+): Promise<void> {
+  log.verbose('Navigating to Crystal Mountain reservation page', verbose);
+  const urls = getUrls(resortUrl);
+  await page.goto(urls.RESERVATIONS, { waitUntil: 'networkidle' });
+  await sleep(SPA_RENDER_DELAY_MS);
+}
+
+/** No lot selection on Crystal (single parking product). */
+export async function selectLotIfNeeded(
+  _page: Page,
+  _lotPreferences: string[] | undefined,
+  verbose: boolean
+): Promise<void> {
+  log.verbose('Crystal Mountain: single product, no lot selection', verbose);
+}
+
+function getDateAvailabilityCrystal(
+  page: Page,
+  dateStr: string,
+  verbose: boolean
+): Promise<'available' | 'sold-out' | 'no-reservation' | 'unavailable' | 'unknown'> {
+  return getDateAvailabilityInternal(page, dateStr, verbose);
+}
+
+async function getDateAvailabilityInternal(
+  page: Page,
+  dateStr: string,
+  verbose: boolean
+): Promise<'available' | 'sold-out' | 'no-reservation' | 'unavailable' | 'unknown'> {
+  const selectors = buildCrystalCalendarDaySelectors(dateStr);
+  let dateElement: ElementHandle | null = null;
+  for (const sel of selectors) {
+    dateElement = await findVisible(page, sel);
+    if (dateElement) break;
+  }
+
+  if (!dateElement) return 'unknown';
+
+  const style = (await dateElement.getAttribute('style')) || '';
+  const className = (await dateElement.getAttribute('class')) || '';
+  const ariaDisabled = await dateElement.getAttribute('aria-disabled');
+
+  const status = parseCrystalAvailability(style, className, ariaDisabled);
+  if (status !== 'unknown') return status;
+
+  if (ariaDisabled === 'true') return 'unavailable';
+  return 'no-reservation';
+}
+
+export async function getDateAvailability(
+  page: Page,
+  dateStr: string,
+  verbose = false
+): Promise<'available' | 'sold-out' | 'no-reservation' | 'unavailable' | 'unknown'> {
+  return getDateAvailabilityCrystal(page, dateStr, verbose);
+}
+
+export async function checkAvailability(
+  page: Page,
+  dateStr: string,
+  verbose = false,
+  resortUrl?: string,
+  _lotPreferences?: string[]
+): Promise<AvailabilityResult> {
+  log.verbose(`[Crystal] Checking availability for ${dateStr}`, verbose);
+
+  await navigateToReservations(page, verbose, resortUrl);
+  await selectLotIfNeeded(page, undefined, verbose);
+
+  const result: AvailabilityResult = {
+    date: dateStr,
+    status: 'unknown',
+    timestamp: new Date(),
+  };
+
+  // Wait for Crystal calendar container
+  await page.waitForSelector(CRYSTAL_SELECTORS.calendar, { timeout: CALENDAR_LOAD_TIMEOUT_MS });
+  await sleep(CALENDAR_RENDER_DELAY_MS);
+
+  const dateSelectors = buildCrystalCalendarDaySelectors(dateStr);
+  let dateElement: ElementHandle | null = null;
+  for (const sel of dateSelectors) {
+    dateElement = await findVisible(page, sel);
+    if (dateElement) break;
+  }
+  let attempts = 0;
+
+  while (!dateElement && attempts < MAX_CALENDAR_NAVIGATION_ATTEMPTS) {
+    const nextBtn = await page.$(CRYSTAL_SELECTORS.navRight);
+    if (!nextBtn) break;
+    const isDisabled = await nextBtn.getAttribute('disabled');
+    if (isDisabled) break;
+    await nextBtn.click();
+    await sleep(MONTH_NAVIGATION_DELAY_MS);
+    for (const sel of dateSelectors) {
+      dateElement = await findVisible(page, sel);
+      if (dateElement) break;
+    }
+    attempts++;
+  }
+
+  if (!dateElement) {
+    result.status = 'unavailable';
+    log.verbose(`Date ${dateStr} not found in Crystal calendar after navigation`, verbose);
+    return result;
+  }
+
+  const dateStatus = await getDateAvailabilityInternal(page, dateStr, verbose);
+  result.status = dateStatus;
+  log.verbose(`[Crystal] Date status: ${dateStatus}`, verbose);
+
+  return result;
+}
+
+/** Crystal has a single parking product; return empty or single placeholder. */
+export async function discoverLots(
+  _page: Page,
+  resortUrl: string,
+  verbose = false
+): Promise<string[]> {
+  log.verbose('Crystal Mountain: single product, no lots to discover', verbose);
+  return [];
+}
+
+export async function waitForLogin(
+  page: Page,
+  verbose = false,
+  resortUrl?: string
+): Promise<boolean> {
+  log.verbose('[Crystal] Waiting for login...', verbose);
+
+  const urls = getUrls(resortUrl);
+  await page.goto(urls.LOGIN, { waitUntil: 'networkidle' });
+
+  try {
+    await page.waitForFunction(
+      () => !window.location.href.includes('/login'),
+      { timeout: 300000 }
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/scraper.ts
+++ b/src/lib/scraper.ts
@@ -1,6 +1,6 @@
 import type { Page, ElementHandle } from 'playwright-core';
 import type { AvailabilityResult } from '../types.js';
-import { getUrls } from '../constants.js';
+import { getUrls, getPlatform } from '../constants.js';
 import { sleep, log } from './utils.js';
 import {
   buildCalendarDaySelector,
@@ -8,6 +8,7 @@ import {
   buildLotDiscoverySelector,
   parseAvailabilityFromStyle,
 } from './selectors.js';
+import * as crystalScraper from './scraper-crystal.js';
 
 // Timing and retry constants
 const CALENDAR_LOAD_TIMEOUT_MS = 15000;
@@ -82,9 +83,12 @@ async function selectLotIfNeeded(page: Page, lotPreferences: string[] | undefine
 }
 
 export async function navigateToReservations(page: Page, verbose = false, resortUrl?: string): Promise<void> {
+  if (getPlatform(resortUrl) === 'crystal') {
+    return crystalScraper.navigateToReservations(page, verbose, resortUrl);
+  }
   log.verbose('Navigating to reservation page', verbose);
   const urls = getUrls(resortUrl);
-  await page.goto(urls.BASE + '/select-parking', { waitUntil: 'networkidle' });
+  await page.goto(urls.RESERVATIONS, { waitUntil: 'networkidle' });
   await sleep(SPA_RENDER_DELAY_MS);
 }
 
@@ -119,6 +123,10 @@ export async function checkAvailability(
   resortUrl?: string,
   lotPreferences?: string[],
 ): Promise<AvailabilityResult> {
+  if (getPlatform(resortUrl) === 'crystal') {
+    return crystalScraper.checkAvailability(page, dateStr, verbose, resortUrl, lotPreferences);
+  }
+
   log.verbose(`Checking availability for ${dateStr}`, verbose);
 
   await navigateToReservations(page, verbose, resortUrl);
@@ -167,7 +175,11 @@ export async function checkAvailability(
 }
 
 export async function discoverLots(page: Page, resortUrl: string, verbose = false): Promise<string[]> {
-  await page.goto(`${resortUrl}/select-parking`, { waitUntil: 'networkidle' });
+  if (getPlatform(resortUrl) === 'crystal') {
+    return crystalScraper.discoverLots(page, resortUrl, verbose);
+  }
+  const urls = getUrls(resortUrl);
+  await page.goto(urls.RESERVATIONS, { waitUntil: 'networkidle' });
   await sleep(LOT_DISCOVERY_DELAY_MS);
   const lotCards = await page.$$(SELECTORS.lotDiscovery);
   const lots: string[] = [];
@@ -180,6 +192,9 @@ export async function discoverLots(page: Page, resortUrl: string, verbose = fals
 }
 
 export async function waitForLogin(page: Page, verbose = false, resortUrl?: string): Promise<boolean> {
+  if (getPlatform(resortUrl) === 'crystal') {
+    return crystalScraper.waitForLogin(page, verbose, resortUrl);
+  }
   log.verbose('Waiting for login...', verbose);
 
   const urls = getUrls(resortUrl);

--- a/src/lib/selectors-crystal.ts
+++ b/src/lib/selectors-crystal.ts
@@ -1,0 +1,49 @@
+/**
+ * Selectors for Crystal Mountain Resort parking (parking.crystalmountainresort.com).
+ *
+ * Crystal's calendar is a custom div-based calendar, not Mobiscroll. Day cells are
+ * `.calendar_day` elements inside `#calendar` and include a `data-date` ISO string
+ * like `2026-03-20T07:00:00.000Z`.
+ */
+
+export const CRYSTAL_SELECTORS = {
+  calendar: '#calendar',
+  navLeft: '#calendarNavLeft',
+  navRight: '#calendarNavRight',
+  /** Day cell for a specific YYYY-MM-DD. */
+  dayCell: (dateStr: string) => `#calendar .calendar_day[data-date^="${dateStr}"]`,
+} as const;
+
+export function buildCrystalCalendarDaySelectors(dateStr: string): string[] {
+  return [
+    CRYSTAL_SELECTORS.dayCell(dateStr),
+  ];
+}
+
+/**
+ * Parse availability from a calendar day element.
+ * Crystal may use inline styles (green = available, red/pink = sold out) or classes.
+ */
+export function parseCrystalAvailability(
+  style: string,
+  className: string,
+  ariaDisabled: string | null
+): 'available' | 'sold-out' | 'no-reservation' | 'unavailable' | 'unknown' {
+  // Crystal uses class names:
+  // - fc-available: reservable / available
+  // - fc-unavailable: sold out
+  // - no-reserve: no reservation required
+  // - calendar_disabled: disabled (past / padding cells)
+  if (ariaDisabled === 'true') return 'unavailable';
+
+  if (className.includes('calendar_disabled')) return 'unavailable';
+  if (className.includes('no-reserve')) return 'no-reservation';
+  if (className.includes('fc-available')) return 'available';
+  if (className.includes('fc-unavailable')) return 'sold-out';
+
+  // Fallbacks (rare; keep for resilience)
+  if (style.includes('fc-available') || /available|open/i.test(className)) return 'available';
+  if (style.includes('fc-unavailable') || /sold|full|unavailable/i.test(className)) return 'sold-out';
+
+  return 'unknown';
+}

--- a/src/lib/selectors.ts
+++ b/src/lib/selectors.ts
@@ -12,6 +12,17 @@ export const CALENDAR_COLORS = {
 export type CalendarColors = typeof CALENDAR_COLORS;
 
 /**
+ * Escape a string for safe use inside a CSS attribute selector [attr="value"].
+ * Commas and other special chars would otherwise break the selector.
+ */
+function escapeCssAttrValue(value: string): string {
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+    return CSS.escape(value);
+  }
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/,/g, '\\,');
+}
+
+/**
  * Format a date string for use in HONK calendar aria-labels.
  * HONK uses Mobiscroll calendar which sets aria-label to full date format.
  *
@@ -53,7 +64,7 @@ export function parseAvailabilityFromStyle(
  */
 export function buildCalendarDaySelector(dateStr: string): string {
   const label = formatDateForAriaLabel(dateStr);
-  return `.mbsc-calendar-day-text[aria-label="${label}"]`;
+  return `.mbsc-calendar-day-text[aria-label="${escapeCssAttrValue(label)}"]`;
 }
 
 /**

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -79,7 +79,7 @@ describe('CLI entry point (index.ts)', () => {
 
     it('shows command descriptions', () => {
       const { stdout } = runCli('--help');
-      expect(stdout).toContain('Authenticate with HONK');
+      expect(stdout).toContain('Authenticate with resort parking site');
       expect(stdout).toContain('Report a bug');
     });
   });

--- a/tests/lib/constants.test.ts
+++ b/tests/lib/constants.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  getPlatform,
+  getUrls,
+  CRYSTAL_MOUNTAIN_URL,
+  DEFAULT_RESORT_URL,
+} from '../../src/constants.js';
+
+describe('getPlatform', () => {
+  it('returns crystal for Crystal Mountain URL', () => {
+    expect(getPlatform(CRYSTAL_MOUNTAIN_URL)).toBe('crystal');
+    expect(getPlatform('https://parking.crystalmountainresort.com')).toBe('crystal');
+    expect(getPlatform('https://parking.crystalmountainresort.com/')).toBe('crystal');
+  });
+
+  it('returns honk for HONK resort URLs', () => {
+    expect(getPlatform(DEFAULT_RESORT_URL)).toBe('honk');
+    expect(getPlatform('https://reservenski.parkstevenspass.com')).toBe('honk');
+    expect(getPlatform('https://reservenski.whistlerblackcombparking.com')).toBe('honk');
+  });
+});
+
+describe('getUrls', () => {
+  it('returns Crystal reservations on BASE for Crystal Mountain', () => {
+    const urls = getUrls(CRYSTAL_MOUNTAIN_URL);
+    expect(urls.BASE).toBe('https://parking.crystalmountainresort.com');
+    expect(urls.LOGIN).toBe('https://parking.crystalmountainresort.com/login');
+    expect(urls.RESERVATIONS).toBe('https://parking.crystalmountainresort.com');
+  });
+
+  it('returns HONK select-parking path for HONK resorts', () => {
+    const urls = getUrls(DEFAULT_RESORT_URL);
+    expect(urls.RESERVATIONS).toBe('https://reservenski.parkstevenspass.com/select-parking');
+  });
+});

--- a/tests/lib/selectors.test.ts
+++ b/tests/lib/selectors.test.ts
@@ -55,14 +55,14 @@ describe('parseAvailabilityFromStyle', () => {
 });
 
 describe('buildCalendarDaySelector', () => {
-  it('builds selector with formatted aria-label', () => {
+  it('builds selector with formatted aria-label (commas escaped for CSS)', () => {
     const selector = buildCalendarDaySelector('2026-02-15');
-    expect(selector).toBe('.mbsc-calendar-day-text[aria-label="Sunday, February 15, 2026"]');
+    expect(selector).toBe('.mbsc-calendar-day-text[aria-label="Sunday\\, February 15\\, 2026"]');
   });
 
   it('handles different dates correctly', () => {
     const selector = buildCalendarDaySelector('2026-03-21');
-    expect(selector).toBe('.mbsc-calendar-day-text[aria-label="Saturday, March 21, 2026"]');
+    expect(selector).toBe('.mbsc-calendar-day-text[aria-label="Saturday\\, March 21\\, 2026"]');
   });
 });
 


### PR DESCRIPTION
Add a Crystal Mountain (parking.crystalmountainresort.com) flow alongside the existing HONK flow.

Detect platform from resortUrl, route reservations URLs appropriately, and implement Crystal calendar selectors/status parsing.

Made-with: Cursor

## Summary

Support Crystal Mountain

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)


## Testing

- [x] I have run `npm test` and all tests pass
- [x] I have run `npm run test:e2e` and e2e tests pass - tests/e2e/watch.test.ts > watch command (E2E) is also failing on base revision
- [ ] I have added tests that prove my fix/feature works
- [ ] I have tested against a real HONK site (if applicable)

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented hard-to-understand areas
- [ ] I have updated documentation (if needed)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged

## Screenshots (if applicable)

<img width="1138" height="816" alt="image" src="https://github.com/user-attachments/assets/d2345fd1-c4c7-4398-972e-3c014663c4aa" />
<img width="1240" height="398" alt="image" src="https://github.com/user-attachments/assets/6d2f5e57-3602-44e8-86e1-b1e95bbb82ca" />

