### PR TITLE
fix: don't reject sessions with no cookies

### DIFF
--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -134,15 +134,12 @@ export interface SessionStatus {
  * Returns status including whether session is expiring soon.
  */
 export async function checkSessionStatus(context: BrowserContext): Promise<SessionStatus> {
-  // Skip check when running against mock server
-  if (process.env.SKI_PARKER_BASE_URL) {
-    return { valid: true };
-  }
-
   const cookies = await context.cookies();
 
+  // No cookies is OK — HONK primarily uses localStorage for auth.
+  // Session validity is confirmed by the actual login check, not cookies alone.
   if (cookies.length === 0) {
-    return { valid: false, warning: 'No session cookies found' };
+    return { valid: true };
   }
 
   // Find auth-related cookies (HONK uses various cookie names)

--- a/tests/e2e/watch.test.ts
+++ b/tests/e2e/watch.test.ts
@@ -83,4 +83,39 @@ describe('watch command (E2E)', () => {
     expect(exitCode).toBe(0);
     expect(stdout).toContain('AVAILABLE');
   }, 90000);
+
+  it('works without session cookies (localStorage-only auth)', async () => {
+    // This reproduces the reported bug: users got "no session cookies found"
+    // after successful auth because HONK uses localStorage, not cookies.
+    // The watch command should proceed without cookies.
+    await setScenarioViaApi({
+      dates: {
+        [AVAILABLE_DATE]: 'available',
+      },
+    });
+
+    const proc = spawn('node', [CLI, 'watch', '--date', AVAILABLE_DATE, '--interval', '3', '--jitter', '0', '--verbose'], {
+      env: { ...process.env, SKI_PARKER_BASE_URL: getMockUrl() },
+    });
+
+    let stdout = '';
+    proc.stdout.on('data', (data: Buffer) => { stdout += data.toString(); });
+    proc.stderr.on('data', (data: Buffer) => { stdout += data.toString(); });
+
+    const exitCode = await new Promise<number>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        proc.kill();
+        reject(new Error(`watch did not exit in time. stdout: ${stdout}`));
+      }, 30000);
+      proc.on('close', (code) => {
+        clearTimeout(timeout);
+        resolve(code ?? 1);
+      });
+    });
+
+    // Should NOT exit with error about "no session cookies found"
+    expect(stdout).not.toContain('No session cookies found');
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('AVAILABLE');
+  }, 60000);
 });

--- a/tests/lib/browser.test.ts
+++ b/tests/lib/browser.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { BrowserContext, Cookie } from 'playwright-core';
+
+// Mock modules with side effects before importing the function under test
+vi.mock('playwright-extra', () => ({
+  chromium: {
+    use: vi.fn(),
+    launch: vi.fn(),
+    launchPersistentContext: vi.fn(),
+  },
+}));
+
+vi.mock('puppeteer-extra-plugin-stealth', () => ({
+  default: vi.fn(() => ({})),
+}));
+
+vi.mock('../../src/lib/config.js', () => ({
+  ensureConfigDir: vi.fn(),
+}));
+
+import { checkSessionStatus } from '../../src/lib/browser.js';
+
+function makeCookie(overrides: Partial<Cookie> = {}): Cookie {
+  return {
+    name: 'test',
+    value: 'value',
+    domain: 'example.com',
+    path: '/',
+    expires: -1,
+    httpOnly: false,
+    secure: false,
+    sameSite: 'Lax',
+    ...overrides,
+  };
+}
+
+function mockContext(cookies: Cookie[]): BrowserContext {
+  return {
+    cookies: vi.fn().mockResolvedValue(cookies),
+  } as unknown as BrowserContext;
+}
+
+describe('checkSessionStatus', () => {
+  const originalEnv = process.env.SKI_PARKER_BASE_URL;
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.SKI_PARKER_BASE_URL = originalEnv;
+    } else {
+      delete process.env.SKI_PARKER_BASE_URL;
+    }
+  });
+
+  it('returns valid when no cookies exist (localStorage-only auth)', async () => {
+    const ctx = mockContext([]);
+    const status = await checkSessionStatus(ctx);
+    expect(status.valid).toBe(true);
+    expect(status.warning).toBeUndefined();
+  });
+
+  it('returns valid when no cookies exist even with SKI_PARKER_BASE_URL set', async () => {
+    process.env.SKI_PARKER_BASE_URL = 'http://localhost:3847';
+    const ctx = mockContext([]);
+    const status = await checkSessionStatus(ctx);
+    expect(status.valid).toBe(true);
+  });
+
+  it('returns valid for session cookies (expires = -1)', async () => {
+    const ctx = mockContext([
+      makeCookie({ name: 'session_id', expires: -1 }),
+    ]);
+    const status = await checkSessionStatus(ctx);
+    expect(status.valid).toBe(true);
+    expect(status.warning).toBeUndefined();
+  });
+
+  it('returns valid for cookies expiring far in the future', async () => {
+    const farFuture = (Date.now() + 30 * 24 * 60 * 60 * 1000) / 1000; // 30 days
+    const ctx = mockContext([
+      makeCookie({ name: 'auth_token', domain: 'honk.com', expires: farFuture }),
+    ]);
+    const status = await checkSessionStatus(ctx);
+    expect(status.valid).toBe(true);
+    expect(status.warning).toBeUndefined();
+    expect(status.expiresAt).toBeDefined();
+  });
+
+  it('returns valid with warning for cookies expiring within 24 hours', async () => {
+    const soonExpiry = (Date.now() + 6 * 60 * 60 * 1000) / 1000; // 6 hours
+    const ctx = mockContext([
+      makeCookie({ name: 'auth_token', domain: 'honk.com', expires: soonExpiry }),
+    ]);
+    const status = await checkSessionStatus(ctx);
+    expect(status.valid).toBe(true);
+    expect(status.warning).toContain('expires in');
+    expect(status.warning).toContain('hours');
+  });
+
+  it('returns invalid for expired cookies', async () => {
+    const pastExpiry = (Date.now() - 60 * 60 * 1000) / 1000; // 1 hour ago
+    const ctx = mockContext([
+      makeCookie({ name: 'auth_token', domain: 'honk.com', expires: pastExpiry }),
+    ]);
+    const status = await checkSessionStatus(ctx);
+    expect(status.valid).toBe(false);
+    expect(status.warning).toContain('expired');
+  });
+
+  it('uses auth cookies when available over generic cookies', async () => {
+    const farFuture = (Date.now() + 30 * 24 * 60 * 60 * 1000) / 1000;
+    const pastExpiry = (Date.now() - 60 * 60 * 1000) / 1000;
+    const ctx = mockContext([
+      makeCookie({ name: 'tracking', expires: pastExpiry }), // expired generic
+      makeCookie({ name: 'auth_token', domain: 'honk.com', expires: farFuture }), // valid auth
+    ]);
+    const status = await checkSessionStatus(ctx);
+    expect(status.valid).toBe(true); // auth cookie is valid
+  });
+
+  it('falls back to all cookies when no auth cookies found', async () => {
+    const pastExpiry = (Date.now() - 60 * 60 * 1000) / 1000;
+    const ctx = mockContext([
+      makeCookie({ name: 'tracking', domain: 'example.com', expires: pastExpiry }),
+    ]);
+    const status = await checkSessionStatus(ctx);
+    expect(status.valid).toBe(false); // expired generic cookie
+  });
+
+  it('reports earliest expiry among multiple auth cookies', async () => {
+    const sooner = (Date.now() + 2 * 60 * 60 * 1000) / 1000; // 2 hours
+    const later = (Date.now() + 20 * 60 * 60 * 1000) / 1000; // 20 hours
+    const ctx = mockContext([
+      makeCookie({ name: 'session_v1', domain: 'honk.com', expires: sooner }),
+      makeCookie({ name: 'token_v2', domain: 'honk.com', expires: later }),
+    ]);
+    const status = await checkSessionStatus(ctx);
+    expect(status.valid).toBe(true);
+    expect(status.warning).toContain('expires in');
+    // Math.floor(2h / 1h) = 2
+    expect(status.warning).toContain('2 hours');
+  });
+
+  it('identifies auth cookies by name pattern', async () => {
+    const farFuture = (Date.now() + 30 * 24 * 60 * 60 * 1000) / 1000;
+    // These names contain 'auth', 'session', or 'token' (case-insensitive)
+    for (const name of ['auth_token', 'session_id', 'access_token', 'MY_SESSION_KEY']) {
+      const ctx = mockContext([
+        makeCookie({ name, expires: farFuture }),
+      ]);
+      const status = await checkSessionStatus(ctx);
+      expect(status.valid).toBe(true);
+    }
+  });
+
+  it('identifies auth cookies by honk domain', async () => {
+    const farFuture = (Date.now() + 30 * 24 * 60 * 60 * 1000) / 1000;
+    const ctx = mockContext([
+      makeCookie({ name: 'xyz', domain: 'app.honk.com', expires: farFuture }),
+    ]);
+    const status = await checkSessionStatus(ctx);
+    expect(status.valid).toBe(true);
+  });
+
+  it('returns expiresInMs for non-expired cookies with expiry', async () => {
+    const farFuture = (Date.now() + 30 * 24 * 60 * 60 * 1000) / 1000;
+    const ctx = mockContext([
+      makeCookie({ name: 'auth_token', expires: farFuture }),
+    ]);
+    const status = await checkSessionStatus(ctx);
+    expect(status.expiresInMs).toBeGreaterThan(0);
+  });
+
+  it('returns expiresInMs as 0 for expired cookies', async () => {
+    const pastExpiry = (Date.now() - 60 * 60 * 1000) / 1000;
+    const ctx = mockContext([
+      makeCookie({ name: 'auth_token', expires: pastExpiry }),
+    ]);
+    const status = await checkSessionStatus(ctx);
+    expect(status.expiresInMs).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug fix**: `checkSessionStatus` was rejecting sessions when no cookies were found, but HONK uses localStorage for auth — not cookies. Users got "no session cookies found" error after successful auth, blocking `watch` command.
- **Removed test-mode bypass**: `checkSessionStatus` no longer short-circuits when `SKI_PARKER_BASE_URL` is set, so e2e tests now exercise the real cookie validation path.
- **Added 13 unit tests** for `checkSessionStatus` covering: empty cookies (the reported bug), session cookies, expired/expiring cookies, auth cookie detection by name and domain, earliest-expiry reporting.
- **Added e2e test** reproducing the exact bug scenario: watch command works without session cookies.

## Test plan

- [x] Unit tests: 72 passing (59 existing + 13 new browser tests)
- [x] E2E tests: 3 watch tests passing (2 existing + 1 new no-cookies test)
- [x] Build: clean compilation
- [x] Rebased on latest main

🤖 Generated with [Claude Code](https://claude.com/claude-code)